### PR TITLE
Fix/node watch dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,16 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 <!-- CONTACT -->
 
 ## Changelog
+v1.2.1
+- Fixed a dependency issue with node-watch
+- Updated readme.
+
+v1.2.0
+- Added the ability for dynamic destination directories
+
 v1.1.0
 - Added module mixin to Pug Library
+
 v1.0.0
 - Soft Launch
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,19 +25,18 @@
   ],
   "dependencies": {
     "colors": "^1.4.0",
-    "jest": "^29.1.2",
     "jsdom": "^20.0.1",
     "pug": "^3.0.2",
     "sass": "^1.54.9",
     "sass-embedded": "^1.55.0",
-    "underscore": "^1.13.6"
+    "underscore": "^1.13.6",
+    "node-watch": "^0.7.3"
   },
   "author": "Scott Casey",
   "devDependencies": {
     "@vitest/ui": "^0.26.2",
     "execa": "^7.0.0",
     "jsdoc": "^3.6.11",
-    "node-watch": "^0.7.3",
     "pug-doc": "^2.23.1",
     "sassdoc": "^2.7.2",
     "vitest": "^0.26.3"


### PR DESCRIPTION
node-watch was listed as a dev dependency. It needed to be a full dependency.