### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 <!-- CONTACT -->
 
 ## Changelog
-v1.2.4
+v1.3.0
 - Fixed an issue that caused the existing key/value pairs of the translation file to be overwritten every time.
 - Fixed an issue that prevented some mixins from using passed attributes (e.g. `+text({name:'my-text'}).quick-class`).
 - Fixed an issue that prevented attribute backed spans from using the attribute prefix that the user has defined.
+- Added a modal mixin
 
 v1.2.3
 - Fixed an issue that caused the build to fail on some linux systems.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 ## Changelog
 v1.2.4
 - Fixed an issue that caused the existing key/value pairs of the translation file to be overwritten every time.
+- Fixed an issue that prevented some mixins from using passed attributes (e.g. `+text({name:'my-text'}).quick-class`).
+- Fixed an issue that prevented attribute backed spans from using the attribute prefix that the user has defined.
 
 v1.2.3
 - Fixed an issue that caused the build to fail on some linux systems.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 <!-- CONTACT -->
 
 ## Changelog
+v1.2.4
+- Fixed an issue that caused the existing key/value pairs of the translation file to be overwritten every time.
+
 v1.2.3
 - Fixed an issue that caused the build to fail on some linux systems.
 

--- a/lib/attribute_holders/_attribute_backed.pug
+++ b/lib/attribute_holders/_attribute_backed.pug
@@ -37,7 +37,7 @@ mixin span(obj)
   - checkKUse();
   - obj.class = obj.class ? replaceProblems(obj.class) : undefined;
   if obj.name
-    - obj.name = replaceSpaces(obj.name);
+    - obj.name = attrName(obj.name);
     - obj.title = obj.title || attrTitle(obj.name);
     - obj.name = `attr_${obj.name}`;
     - addFieldToFieldsetObj(obj);

--- a/lib/attribute_holders/_inputs.pug
+++ b/lib/attribute_holders/_inputs.pug
@@ -31,7 +31,7 @@ mixin input(obj)
     +text({name:'my attribute',class:'some-class',trigger:{affects:['other_attribute']}})
 mixin text(obj)
   - obj.type = 'text';
-  +input(obj)
+  +input(obj)&attributes(attributes)
 //-End Mixin
 
 //- @pugdoc
@@ -74,7 +74,7 @@ mixin collapse(name='collapse')
     +radio({name:'my radio',value:3})
 mixin radio(obj)
   - obj.type = 'radio';
-  +input(obj)
+  +input(obj)&attributes(attributes)
 //-End Mixin
 
 //- @pugdoc
@@ -88,7 +88,7 @@ mixin radio(obj)
     +number({name:'my number',class:'some-class',trigger:{affects:['other_attribute']}})
 mixin number(obj)
   - obj.type = 'number';
-  +input(obj)
+  +input(obj)&attributes(attributes)
 //-End Mixin
 
 //- @pugdoc
@@ -102,7 +102,7 @@ mixin number(obj)
     +range({name:'my range',class:'some-class'})
 mixin range(obj)
   - obj.type = 'range';
-  +input(obj)
+  +input(obj)&attributes(attributes)
 //-End Mixin
 
 //- @pugdoc
@@ -116,7 +116,7 @@ mixin range(obj)
     +hidden({name:'my hidden attribute',class:'some-class',trigger:{triggeredFuncs:['someFunction']}})
 mixin hidden(obj)
   - obj.type = 'hidden';
-  +input(obj)
+  +input(obj)&attributes(attributes)
 //-End Mixin
 
 mixin radioGroup(objArray)

--- a/lib/render/outputPug.js
+++ b/lib/render/outputPug.js
@@ -48,7 +48,7 @@ const outputPug = async (html,destination,testDestination) => {
     const currTranslation = await fs.readFile(transPath,'utf8')
       .then(t => JSON.parse(t))
       .catch( e => {return {}});
-    const toUse = {...currTranslation,...translations};
+    const toUse = {...translations,...currTranslation};
     await fs.writeFile(transPath,JSON.stringify(toUse,null,2));
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
v1.2.4
- Fixed an issue that caused the existing key/value pairs of the translation file to be overwritten every time.
- Fixed an issue that prevented some mixins from using passed attributes (e.g. `+text({name:'my-text'}).quick-class`).
- Fixed an issue that prevented attribute backed spans from using the attribute prefix that the user has defined.
- Added a modal mixin