### PR TITLE
Update doc release action for pages; fixed orderSection error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,14 +71,18 @@ jobs:
 
   doc:
     needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: production-files
+        path: ./docs
+
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 <!-- CONTACT -->
 
 ## Changelog
+v1.5.0
+- Fixed an error in `orderSection`/`orderSections` that caused rowIDs to be improperly ordered when IDs were a mix of user ordered and unordered IDS. **NOTE** This changes how `orderSection` works. It now returns the ordered array instead of mutating the ID array in place.
 v1.4.2
 - Fixed an issue that prevented translation automation from handling complex i18n entities like `data-i18n-placeholder`.
 

--- a/lib/scripts/utility.js
+++ b/lib/scripts/utility.js
@@ -232,7 +232,7 @@ kFuncs.debug = debug;
 const orderSections = function(attributes,sections){
   Object.keys(sections).forEach((section)=>{
     attributes.attributes[`_reporder_${section}`] = commaArray(attributes[`_reporder_${section}`]);
-    orderSection(attributes.attributes[`_reporder_${section}`],sections[section]);
+    sections[section] = orderSection(attributes.attributes[`_reporder_${section}`],sections[section]);
   });
 };
 kFuncs.orderSections = orderSections;
@@ -241,12 +241,12 @@ kFuncs.orderSections = orderSections;
  * Orders a single ID array.
  * @memberof Utilities
  * @param {string[]} repOrder - Array of IDs in the order they are in on the sheet.
- * @param {string[]} IDs - Array of IDs to be ordered.
+ * @param {string[]} IDs - Array of IDs to be ordered. Aka the default ID Array passed to the getSectionIDs callback
+ * @returns {string[]} - The ordered id array
  */
 const orderSection = function(repOrder,IDs=[]){
-  IDs.sort((a,b)=>{
-    return repOrder.indexOf(a.toLowerCase()) - repOrder.indexOf(b.toLowerCase());
-  });
+  const idArr = [...repOrder,...IDs.filter(id => !repOrder.includes(id.toLowerCase()))];
+  return idArr;
 };
 kFuncs.orderSection = orderSection;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- Updated doc release action to hopefully update doc site correctly.
- Fixed an error in `orderSection`/`orderSections` that caused rowIDs to be improperly ordered when IDs were a mix of user ordered and unordered IDS.