### PR TITLE
Feature/full templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Distributed under the mit License. See [LICENSE.txt](https://github.com/Kurohyou
 <!-- CONTACT -->
 
 ## Changelog
+v1.7.0
+- Added ability to template sheet.json, and instructions property of sheet.json.
+  - Instructions can be templated by adding a `readme.md` file to your source directory. This will be converted to sheet.json format and added as the instructions format. If no readme is provided, instructions property will not be set/will use what was in the sheet.json template file.
+  - The html and css properties will use the generated html and css file names as their values
+  - Works with dynamic directory setting
+  - the preview property will use either the value set in the template file or will default to .jpg file named the same as the generated html file.
 v1.6.1
 - Fixed a crash in watch from the translation template changes.
 

--- a/lib/render/index.js
+++ b/lib/render/index.js
@@ -15,15 +15,15 @@ const processSheet = require('./processSheet');
  * @param {object} [pugOptions] - Options for how the k-scaffold should parse the pug and options that should be passed to pugjs. Accepts all options specified at pugjs.org. To be explicit as the pugjs docs are obtuse on this point, you may pass any local variables/functions that you want to have access to in your pug via this object. In addition you may pass:
  * @param {boolean} [pugOptions.suppressStack = true] - Whether the K-scaffold should suppress the full error stack from pug and only display the message portion of the error. The stack traces provided by pug do not refer to the actual chain of included pug files, and so are usually useless in troubleshooting an issue.
  * @param {object} [scssOptions = {}] - Options for how the k-scaffold should parse the SCSS and options that should be passed to SASS. Accepts all options specified at sass-lang.com.
- * @param {string} [translationTemplate] - A directory that contains the template translation file. Template translation file should be named translation.json just like the build version of the translation file.
- * @returns {Promise<array[]>} - Array containing all rendered HTML text in an array at index 0 and all rendered CSS text at index 1.
+ * @param {string} [templates] - A directory that contains the template files for translation.json, sheet.json, and readme. Template translation file should be named translation.json just like the build version of the translation file.
+ * @returns {Promise<array[]>} - Array containing all rendered HTML text in an array at index 0, all rendered CSS text at index 1, and rendered sheet.json at index 2.
  */
-const build = async ({source ='./',destination,dynamicDestination,testDestination,pugOptions={suppressStack:true},scssOptions={},watch=false,translationTemplate}) => {
-  const [html,css] = await processSheet({source,destination,dynamicDestination,testDestination,pugOptions,scssOptions,translationTemplate});
+const build = async ({source ='./',destination,dynamicDestination,testDestination,pugOptions={suppressStack:true},scssOptions={},watch=false,templates}) => {
+  const [html,css,json] = await processSheet({source,destination,dynamicDestination,testDestination,pugOptions,scssOptions,templates});
   if(watch){
-    return watchSheet({source,destination,dynamicDestination,testDestination,pugOptions,scssOptions,translationTemplate});
+    return watchSheet({source,destination,dynamicDestination,testDestination,pugOptions,scssOptions,templates});
   }else{
-    return [html,css];
+    return [html,css,json];
   }
 };
 

--- a/lib/render/outputPug.js
+++ b/lib/render/outputPug.js
@@ -5,7 +5,7 @@ const { JSDOM } = jsdom;
 
 const outputTests = require('./outputTests');
 
-const outputPug = async (html,destination,testDestination,translationTemplate) => {
+const outputPug = async (html,destination,testDestination,templates) => {
   if(!destination) return;
   const destDir = path.dirname(destination);
   await fs.mkdir(destDir,{recursive:true});
@@ -46,8 +46,8 @@ const outputPug = async (html,destination,testDestination,translationTemplate) =
   },{});
   if(translations){
     const transPath = path.resolve(path.dirname(destination),'translation.json');
-    const templatePath = translationTemplate ?
-      path.resolve(translationTemplate,'translation.json') :
+    const templatePath = templates ?
+      path.resolve(templates,'translation.json') :
       null;
     const currTranslation = await (
       templatePath ?

--- a/lib/render/processSheet.js
+++ b/lib/render/processSheet.js
@@ -4,6 +4,7 @@ const kStatus = require('./kStatus');
 const resolvePaths = require('./resolvePaths');
 const renderSASS = require('./renderSASS');
 const renderPug = require('./renderPug');
+const renderTemplates = require('./renderTemplates');
 
 const isSASS = async ({entry,source:resSource,destination:resDest,options,runSCSS}) => {
   if(runSCSS && entry.name.endsWith('.scss')){
@@ -12,25 +13,30 @@ const isSASS = async ({entry,source:resSource,destination:resDest,options,runSCS
   }
 };
 
-const isPUG = async ({entry,source:resSource,destination:resDest,testDestination,options,runPUG,translationTemplate}) => {
+const isPUG = async ({entry,source:resSource,destination:resDest,testDestination,options,runPUG,templates}) => {
   if(runPUG && entry.name.endsWith('.pug')){
     kStatus(` Processing ${entry.name} `);
-    return renderPug({source:resSource,destination:resDest,testDestination,options,translationTemplate});
+    return renderPug({source:resSource,destination:resDest,testDestination,options,templates});
   }
 
 };
 
-const processSheet = async ({source ='./',destination,dynamicDestination = false,testDestination,pugOptions={suppressStack:true},scssOptions={},runSCSS=true,runPUG=true, translationTemplate}) => {
+const processSheet = async ({source ='./',destination,dynamicDestination = false,testDestination,pugOptions={suppressStack:true},scssOptions={},runSCSS=true,runPUG=true, templates}) => {
   const files = await fs.opendir(source);
   const pugPromises = [];
   const scssPromises = [];
+  const destinations = {};
   for await (entry of files){
     if(entry.isFile() && !entry.name.startsWith('_') && (entry.name.endsWith('.pug') || entry.name.endsWith('.scss'))){
       const [resSource,resDest] = resolvePaths(source,destination,dynamicDestination,entry);
-
+      const [,destDir,fileName] = resDest.match(/(.+?)[\\\/]([^\\\/]+)$/) || [];
+      if(destDir && fileName){
+        destinations[destDir] = destinations[destDir] || [];
+        destinations[destDir].push(fileName);
+      }
       const newSASS = await isSASS({entry,source:resSource,destination:resDest,options:scssOptions,runSCSS});
 
-      const newPUG = await isPUG({entry,source:resSource,destination:resDest,testDestination,options:pugOptions,runPUG,translationTemplate});
+      const newPUG = await isPUG({entry,source:resSource,destination:resDest,testDestination,options:pugOptions,runPUG,templates});
 
       if(newSASS){
         scssPromises.push(newSASS);
@@ -42,7 +48,8 @@ const processSheet = async ({source ='./',destination,dynamicDestination = false
   }
   const pugOutput = await Promise.all(pugPromises);
   const scssOutput = await Promise.all(scssPromises);
-  return [pugOutput,scssOutput];
+  const templateOutput = await renderTemplates(destinations,templates);
+  return [pugOutput,scssOutput,templateOutput];
 };
 
 module.exports = processSheet;

--- a/lib/render/renderPug.js
+++ b/lib/render/renderPug.js
@@ -14,7 +14,7 @@ const outputPug = require('./outputPug');
  * @returns {Promise<string|null>} - The rendered HTML or null if an error occurred
  */
 
-const renderPug = async ({source,destination,testDestination,options={suppressStack:true},translationTemplate}) => {
+const renderPug = async ({source,destination,testDestination,options={suppressStack:true},templates}) => {
   const template = await getTemplate(source);
   try{
     const k = require('./locals');
@@ -26,7 +26,7 @@ const renderPug = async ({source,destination,testDestination,options={suppressSt
       filename:source,
       basedir:path.dirname(process.argv[1])
     });
-    await outputPug(html,destination,testDestination,translationTemplate);
+    await outputPug(html,destination,testDestination,templates);
     return html;
   }catch(err){
     if(err.message.endsWith('kScript mixin already used. Kscript should be the final mixin used in the sheet code.')){

--- a/lib/render/renderTemplates.js
+++ b/lib/render/renderTemplates.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const fs = require('fs/promises');
+const kStatus = require('./kStatus');
+
+const renderTemplates = async (destination,sourceDir) => {
+  if(!sourceDir) return;
+  return Promise.all(
+    Object
+      .entries(destination)
+      .map(async([destDir,files]) =>{
+        kStatus(` Processing sheet.json and readme template for ${files[0].replace(/\..+$/,'')}`);
+        const readmeTemplatePath = path.resolve(sourceDir,'readme.md');
+        const jsonTemplatePath = path.resolve(sourceDir,'sheet.json');
+        let readme = '';
+        let sheetJSON = {};
+        const sheetDestPath = path.resolve(destDir,'sheet.json');
+        try{
+          readme = await fs.readFile(readmeTemplatePath,'utf8')
+            .then()
+            .catch(e => e);
+        }catch(err){
+          // Do nothing
+        }
+        try{
+          sheetJSON = await fs.readFile(jsonTemplatePath,'utf8')
+            .then(t => JSON.parse(t))
+            .catch(e => ({}));
+        }catch(err){
+          // Do nothing
+        }
+        sheetJSON.legacy = false;
+        files.forEach(file => {
+          const [fileName,fileType] = file.match(/.+?\.(.+)$/);
+          sheetJSON[fileType.toLowerCase()] = fileName;
+        });
+        sheetJSON.preview = sheetJSON.preview ||
+          sheetJSON.html.replace(/\.html/,'.jpg');
+        if(readme){
+          sheetJSON.instructions = readme.replace(/\n/g,'\\n');
+        }
+        return fs.writeFile(sheetDestPath,JSON.stringify(sheetJSON,null,2))
+      })
+  );
+};
+
+module.exports = renderTemplates;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.2.3",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kurohyou/k-scaffold",
-      "version": "1.2.3",
+      "version": "1.6.1",
       "dependencies": {
         "colors": "^1.4.0",
         "jsdom": "^20.0.1",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "dependencies": {
     "colors": "^1.4.0",
     "jsdom": "^20.0.1",
+    "node-watch": "^0.7.3",
     "pug": "^3.0.2",
     "sass": "^1.54.9",
     "sass-embedded": "^1.55.0",
-    "underscore": "^1.13.6",
-    "node-watch": "^0.7.3"
+    "underscore": "^1.13.6"
   },
   "author": "Scott Casey",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- Added ability to template sheet.json, and instructions property of sheet.json.
  - Instructions can be templated by adding a `readme.md` file to your source directory. This will be converted to sheet.json format and added as the instructions format. If no readme is provided, instructions property will not be set/will use what was in the sheet.json template file.
  - The html and css properties will use the generated html and css file names as their values
  - Works with dynamic directory setting
  - the preview property will use either the value set in the template file or will default to .jpg file named the same as the generated html file.