### PR TITLE
fix: input mixin error out on missing type

### DIFF
--- a/lib/attribute_holders/_inputs.pug
+++ b/lib/attribute_holders/_inputs.pug
@@ -11,7 +11,8 @@
     +input({name:'my attribute',type:'text',class:'some-class',trigger:{affects:['other_attribute']}})
 mixin input(obj)
   - checkKUse();
-  - if (! obj.hasOwnProperty('type')) { throw new Error("+input() mixin was called without a 'type', roll20 will not detect the attribute."); };
+  if !obj.hasOwnProperty('type')
+    - throw new Error(`+input() mixin for "${obj.name}" was called without a 'type', roll20 will not detect the attribute.`);
   - obj.class = obj.class ? replaceProblems(obj.class) : undefined;
   - obj.name = attrName(obj.name);
   - obj.title = obj.title || attrTitle(obj.name);

--- a/lib/attribute_holders/_inputs.pug
+++ b/lib/attribute_holders/_inputs.pug
@@ -11,6 +11,7 @@
     +input({name:'my attribute',type:'text',class:'some-class',trigger:{affects:['other_attribute']}})
 mixin input(obj)
   - checkKUse();
+  - if (! obj.hasOwnProperty('type')) { throw new Error("+input() mixin was called without a 'type', roll20 will not detect the attribute."); };
   - obj.class = obj.class ? replaceProblems(obj.class) : undefined;
   - obj.name = attrName(obj.name);
   - obj.title = obj.title || attrTitle(obj.name);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bin": {
     "k-build": "cli.mjs"
   },
+  "keywords": [
+    "Roll20",
+    "Character Sheets",
+    "Node",
+    "ECMAScript"
+  ],
   "scripts": {
     "full-install": "npm i && cd test_sheet && npm i && cd ../docs && npm i",
     "docs": "node docGen",

--- a/test_sheet/source/typeError.pug
+++ b/test_sheet/source/typeError.pug
@@ -1,0 +1,2 @@
+include k-scaffold
++input({name:'attribute without type'})


### PR DESCRIPTION
If the `type` is not provided to input, Roll20 doesn't detect the attribute and it is not saved. In that case, throw an error during PUG compilation.