### PR TITLE
fix: pass pug attribute to wrapped html in _attribute_backed.pug

### DIFF
--- a/lib/attribute_holders/_attribute_backed.pug
+++ b/lib/attribute_holders/_attribute_backed.pug
@@ -18,7 +18,7 @@ mixin img(obj)
   - const elementObj = makeElementObj(obj);
   - addFieldToFieldsetObj(obj);
   - storeTrigger(obj);
-  img&attributes(elementObj)
+  img&attributes(elementObj)&attributes(attributes)
 //-End Mixin
 
 
@@ -44,7 +44,7 @@ mixin span(obj)
     - obj.name = `attr_${obj.name}`;
     - addFieldToFieldsetObj(obj);
   - const elementObj = makeElementObj(obj);
-  span&attributes(elementObj)
+  span&attributes(elementObj)&attributes(attributes)
     block
   if obj.name
     - obj.type = 'span';
@@ -72,6 +72,6 @@ mixin div(obj)
     - obj.name = replaceSpaces(obj.name);
     - obj.title = obj.title || attrTitle(obj.name);
     - obj.name = `attr_${obj.name}`;
-  div&attributes(obj)
+  div&attributes(obj)&attributes(attributes)
     block
 //-End Mixin

--- a/lib/attribute_holders/_compendium.pug
+++ b/lib/attribute_holders/_compendium.pug
@@ -24,7 +24,7 @@ mixin compendiumAttributes({prefix,lookupAttributes = ['Name','data'],triggerAcc
     - let inputObj = {name:`${prefix}drop ${accept.toLowerCase()}`,accept,value:''};
     if accept === triggerAccept
       - inputObj.trigger = trigger;
-    +hidden(inputObj)
+    +hidden(inputObj)&attributes(attributes)
 //- End Mixin
 
 //- @pugdoc

--- a/lib/attribute_holders/_inputs.pug
+++ b/lib/attribute_holders/_inputs.pug
@@ -152,5 +152,5 @@ mixin textarea(obj)
   - addFieldToFieldsetObj(obj);
   - storeTrigger(obj);
   - const elementObj = makeElementObj(obj);
-  textarea&attributes(elementObj)
+  textarea&attributes(elementObj)&attributes(attributes)
 //-End Mixin

--- a/lib/fieldsets/_fieldsets.pug
+++ b/lib/fieldsets/_fieldsets.pug
@@ -37,7 +37,7 @@ mixin fieldset({name,trigger,addClass})
     - storeTrigger({name:section,type:'fieldset',trigger})
   if addClass
     span(hidden="" class=addClass)
-  fieldset(class=`${section}`)
+  fieldset(class=`${section}`)&attributes(attributes)
     block
   - k.repeatingPrefix = '';
 //-End Mixin
@@ -74,7 +74,7 @@ mixin customControlFieldset({name,trigger,addClass})
       name;
   +action({name:`add ${buttonName}`,class:'repcontrol-button repcontrol-button--add',trigger:{listenerFunc:'addItem'}})
   - setSystemPrefix(prefixHolder);
-  +fieldset({name,trigger,addClass})
+  +fieldset({name,trigger,addClass})&attributes(attributes)
     block
 //- End Mixin
 
@@ -104,7 +104,7 @@ mixin repeating_section(name,header,columnArr,id)
       .repeat-columns
         each head in columnArr
           h5(data-i18n=head)
-    +customControlFieldset({name: name})
+    +customControlFieldset({name: name})&attributes(attributes)
       block
 //- End Mixin
 
@@ -131,7 +131,7 @@ mixin inlineFieldset({name,trigger,addClass})
   - varObjects.inlineFieldsets.push(name);
   
   +action({name:`add ${name}`,class:'repcontrol-button repcontrol-button--add repcontrol-button--inline',trigger:{listenerFunc:'sectionInteract'}})
-  +fieldset({name,trigger,addClass})
+  +fieldset({name,trigger,addClass})&attributes(attributes)
     +radio({name:'display state',class:'display-control',value:'short-display',hidden:''})
     .inline-fieldset__summary.display-target
       label.pointer

--- a/lib/labels/_labels.pug
+++ b/lib/labels/_labels.pug
@@ -22,7 +22,7 @@ mixin button-label({inputObj,buttonObj,divObj})
   - buttonObj.class = buttonObj.class ? replaceProblems(buttonObj.class) : undefined;
   - inputObj.name = inputObj.name.replace(/\s+/g,'_');
   - buttonObj.name = (buttonObj.name || inputObj.name).replace(/\s+/g,'_');
-  .input-label.input-label--button&attributes(divObj)
+  .input-label.input-label--button&attributes(divObj)&attributes(attributes)
     - inputObj.class = inputObj.class ? `${inputObj.class} input-label__input` : 'input-label__input';
     if spanObj
       - buttonObj.class = buttonObj.class ? `${buttonObj.class} input-label__text` : 'input-label__text';
@@ -51,7 +51,7 @@ mixin button-label({inputObj,buttonObj,divObj})
     })
 mixin roller-label({inputObj,buttonObj,divObj})
   +rollerExtras(buttonObj)
-    +button-label({inputObj,buttonObj,divObj})
+    +button-label({inputObj,buttonObj,divObj})&attributes(attributes)
 //-End Mixin
 
 
@@ -75,7 +75,7 @@ mixin roller-label({inputObj,buttonObj,divObj})
     })
 mixin action-label({inputObj,buttonObj,divObj})
   - buttonObj.type = 'action';
-  +button-label({inputObj,buttonObj,divObj})
+  +button-label({inputObj,buttonObj,divObj})&attributes(attributes)
 //-End Mixin
 
 
@@ -109,7 +109,7 @@ mixin select-label({label,inputObj,divObj,spanObj})
     - inputObj.class = inputObj.class ? replaceProblems(inputObj.class) : undefined;
   if spanObj
     - spanObj.class = spanObj.class ? replaceProblems(spanObj.class) : undefined;
-  label.input-label&attributes(divObj)
+  label.input-label&attributes(divObj)&attributes(attributes)
     - inputObj.name = inputObj.name.replace(/\s+/g,'_');
     - inputObj.class = inputObj.class ? `${inputObj.class} input-label__input` : 'input-label__input';
     if spanObj
@@ -147,7 +147,7 @@ mixin input-label({label,inputObj,divObj,spanObj})
     - inputObj.class = inputObj.class ? replaceProblems(inputObj.class) : undefined;
   if spanObj
     - spanObj.class = spanObj.class ? replaceProblems(spanObj.class) : undefined;
-  label.input-label&attributes(divObj)
+  label.input-label&attributes(divObj)&attributes(attributes)
     - inputObj.name = inputObj.name.replace(/\s+/g,'_');
     - inputObj.class = inputObj.class ? `${inputObj.class} input-label__input` : 'input-label__input';
     if spanObj
@@ -161,7 +161,7 @@ mixin dual-input-label({label,inputArr,divObj,spanObj})
     - divObj.class = divObj.class ? replaceProblems(divObj.class) : undefined;
   if spanObj
     - spanObj.class = spanObj.class ? replaceProblems(spanObj.class) : undefined;
-  .input-label.input-label--dual&attributes(divObj)
+  .input-label.input-label--dual&attributes(divObj)&attributes(attributes)
     span(data-i18n=label)&attributes(spanObj)
     each inputObj,i in inputArr
       if inputObj

--- a/lib/rolltemplate/_rolltemplate.pug
+++ b/lib/rolltemplate/_rolltemplate.pug
@@ -12,7 +12,7 @@
     +rolltemplate('my-rolltemplate')
       //- Some roll template content
 mixin rolltemplate(name)
-  rolltemplate(class=`sheet-rolltemplate-${name}`)
+  rolltemplate(class=`sheet-rolltemplate-${name}`)&attributes(attributes)
     block
 //- End Mixin
 //- @pugdoc
@@ -28,7 +28,7 @@ mixin rolltemplate(name)
     +templateWrapper('my-template')
 mixin templateWrapper(name)
   +rolltemplate(name)
-    div(class=`template ${name}`)
+    div(class=`template ${name}`)&attributes(attributes)
       block
 //- End Mixin
 //- @pugdoc
@@ -47,7 +47,7 @@ mixin multiPartTemplate(name)
   rolltemplate(class=`sheet-rolltemplate-${name}`)
     +templateHelperFunction({func:'rollBetween',values:'computed::finished 0 0',invert:true})
       span(class='finished')
-    div(class=`template ${name}{{#continuation}} continuation{{/continuation}}{{#first}} first{{/first}} finished`)
+    div(class=`template ${name}{{#continuation}} continuation{{/continuation}}{{#first}} first{{/first}} finished`)&attributes(attributes)
       block
 //- End Mixin
 //- @pugdoc


### PR DESCRIPTION
Pass PUG attributes to the underlying HTML generation in `_attribute_backed.pug`. This use the same system as e.g. https://github.com/Kurohyou-Studios/k-scaffold/blob/61897632a8ee11a56d641a3792b1ee719fc0db37/lib/attribute_holders/_inputs.pug#L21