### PR TITLE
collapse nesting hover display

### DIFF
--- a/lib/attribute_holders/_collapse.scss
+++ b/lib/attribute_holders/_collapse.scss
@@ -35,11 +35,11 @@
   .repitem,
   .collapse-container{
     &:hover{
-      .collapse,.roll-container{
+      > .collapse,.roll-container{
         opacity:var(--collapseHoverOpacity);
       }
     }
-    .collapse{
+    > .collapse{
       opacity:var(--collapseBaseOpacity);
       position:absolute;
       right:-10px;


### PR DESCRIPTION
Fixes collapse container styling so that nested collapse containers don't display their collapse checkboxes unless they are hovered over.