### PR TITLE
Fixed --unselectedColor2

### DIFF
--- a/lib/generic_scss/_darkmode.scss
+++ b/lib/generic_scss/_darkmode.scss
@@ -12,7 +12,7 @@
   --backColor:var(--dm-backColor);
   --selectedColor:var(--dm-selectedColor);
   --unselectedColor1:var(--dm-unselectedColor1);
-  --unselectedColor1:var(--dm-unselectedColor2);
+  --unselectedColor2:var(--dm-unselectedColor2);
   --checkColor:var(--dm-checkColor);
   --borderColor:var(--dm-borderColor);
   --fontColor:var(--dm-fontColor);

--- a/lib/generic_scss/variables/_colors.scss
+++ b/lib/generic_scss/variables/_colors.scss
@@ -19,7 +19,7 @@
 
   --lm-unselectedColor2:transparent;
   --dm-unselectedColor2:transparent;
-  --unselectedColor1:var(--lm-unselectedColor2);
+  --unselectedColor2:var(--lm-unselectedColor2);
 
   --lm-checkColor:#000;
   --dm-checkColor:#ff0000;


### PR DESCRIPTION
While digging through the variables, we noticed that --unselectedColor1 was getting overwritten, instead of the (probably) intended --unselectedColor2.  This PR fixes that for both light and dark modes.