### PR TITLE
Add --checkedBackColor to the dark mode styling

### DIFF
--- a/lib/generic_scss/_darkmode.scss
+++ b/lib/generic_scss/_darkmode.scss
@@ -14,6 +14,7 @@
   --unselectedColor1:var(--dm-unselectedColor1);
   --unselectedColor1:var(--dm-unselectedColor2);
   --checkColor:var(--dm-checkColor);
+  --checkedBackColor:var(--dm-checkedBackColor);
   --borderColor:var(--dm-borderColor);
   --fontColor:var(--dm-fontColor);
   --disabledColor:var(--dm-disabledColor);


### PR DESCRIPTION
While digging through the sheet styling, we noticed that --checkedBackColor was referenced in several places, including light mode styling, but wasn't set in dark mode styling.  This PR sets it for dark mode.