### PR TITLE
fix: fix scss not using mixin havong too low specificity

### DIFF
--- a/lib/_k.scss
+++ b/lib/_k.scss
@@ -1,12 +1,15 @@
 @forward 'generic_scss/genericStyle';
 @use 'generic_scss/genericStyle';
-@forward 'tabs/_tabs.scss';
-@use 'tabs/_tabs.scss';
+
+@forward 'tabs/tabsStyling.scss';
+@use 'tabs/tabsStyling.scss';
 
 @forward 'attribute_holders/attributeConstructs';
 @use 'attribute_holders/attributeConstructs';
+
 @forward 'labels/labels';
 @use 'labels/labels';
+
 @forward 'adaptive/adaptive';
 @use 'adaptive/adaptive';
 
@@ -16,8 +19,9 @@
 @use 'rolltemplate/_rolltemplate';
 @forward 'rolltemplate/_rolltemplate';
 
-@use 'modal/_modal';
-@forward 'modal/_modal';
+@use 'modal/modalStyling';
+@forward 'modal/modalStyling';
+
 /// Mixin that includes all of the framework's styles. Should be included in a 3 class declaration for character sheets.
 /// @example
 ///   @use 'k-scaffold' as k;
@@ -25,7 +29,7 @@
 ///   .ui-dialog .tab-content .charsheet{
 ///     @include k.defaultStyles;
 ///   }
-@mixin defaultStyles{
+@mixin defaultStyles {
   // Clear roll20 styles
   @include genericStyle.clear;
 
@@ -33,7 +37,7 @@
   @include genericStyle.layout;
   @include genericStyle.borderStyles;
   @include genericStyle.sizesAndRatios;
-  
+
   // Text stylings
   @include genericStyle.textElements;
   @include genericStyle.materialIcons;
@@ -52,6 +56,8 @@
   @include adaptive.adaptiveText;
 
   @include fieldsetStyling.fieldsetStyling;
+  @include modalStyling.modalStyling;
+  @include tabsStyling.tabsStyling;
 }
 
 /// Mixin that includes all of the default styles as well as rolltemplate specific styling such as inline roll variable assignment. Should be included directly in the rolltemplate declaration for your roll templates.
@@ -61,10 +67,11 @@
 ///   .sheet-rolltemplate-TEMPLATENAME{
 ///     @include k.defaultRollStyling;
 ///   }
-@mixin defaultRollStyling{
+@mixin defaultRollStyling {
   @include defaultStyles;
   @include rolltemplate.rollStyles;
 }
-@mixin rollVariables{
+
+@mixin rollVariables {
   @include rolltemplate.rollVariables;
 }

--- a/lib/modal/_modalStyling.scss
+++ b/lib/modal/_modalStyling.scss
@@ -1,4 +1,4 @@
-.ui-dialog .tab-content .charsheet {
+@mixin modalStyling {
 
     // make the top-level .charsheet div the default root of "position: absolute;" elements
     position: relative;
@@ -6,7 +6,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    
+
     //- Use 'kmodal' instead of modal, because Roll20 already uses a 'modal' class
 
     .kmodal__button {
@@ -17,7 +17,7 @@
         cursor: pointer;
     }
 
-    .kmodal__checkbox {
+    .kmodal__checkbox[type=checkbox] {
         display: none;
     }
 
@@ -49,18 +49,18 @@
 
     .kmodal__inner {
         position: fixed;
-        width:var(--kmodal-width);
-        height:var(--kmodal-height);
-        inset:0;
+        width: var(--kmodal-width);
+        height: var(--kmodal-height);
+        inset: 0;
         margin: auto;
         overflow: auto;
         background: var(--kmodal-dialog-background);
         border-radius: 5px;
         padding: var(--kmodal-close-height) calc(var(--kmodal-close-width) * 3) var(--kmodal-close-height) calc(var(--kmodal-close-width) * 2);
-        max-width:var(--kmodal-max-width);
-        max-height:var(--kmodal-max-height);
+        max-width: var(--kmodal-max-width);
+        max-height: var(--kmodal-max-height);
         transition: opacity .25s ease;
-        box-shadow:var(--kmodal-box-shadow);
+        box-shadow: var(--kmodal-box-shadow);
     }
 
 

--- a/lib/tabs/_tabs.scss
+++ b/lib/tabs/_tabs.scss
@@ -1,9 +1,0 @@
-.tabs__container:not(.k-active-tab) {
-    display: none !important;
-}
-.tabs__nav-item{
-    list-style:none;
-}
-.tabs__nav-list{
-    display:flex;
-}

--- a/lib/tabs/_tabsStyling.scss
+++ b/lib/tabs/_tabsStyling.scss
@@ -1,0 +1,15 @@
+@mixin tabsStyling {
+
+
+    .tabs__container:not(.k-active-tab) {
+        display: none !important;
+    }
+
+    .tabs__nav-item {
+        list-style: none;
+    }
+
+    .tabs__nav-list {
+        display: flex;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "2.5.3",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kurohyou/k-scaffold",
-      "version": "2.5.3",
+      "version": "2.5.6",
       "dependencies": {
         "colors": "^1.4.0",
         "i18nreplacer": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "This framework simplifies the task of writing code for Roll20 character sheets. It aims to provide an easier interface between the html and sheetworkers with some minor css templates.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
In this PR, I change tabs and modal windows SCSS to follow the same pattern as the rest of the library, to make sure they get the same specificity as the default styles, or higher when necessary.

See also the [discord message](https://discord.com/channels/684431703036657698/684431703036657842/1229004077610827806)

Of note, I did not manage to test this fix due to #127 