### PR TITLE
fix: fix dev installation and possibly yarn not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const build = require('./lib/render');
+const sass = require('sass-embedded');
 
 module.exports = {
-  scss:(o)=>build({...o,runSCSS:false}),
-  pug:(o)=>build({...o,runPUG:false}),
-  all:build
+  scss: (o) => build({ ...o, runSCSS: false }),
+  pug: (o) => build({ ...o, runPUG: false }),
+  all: build,
+  sass
 };

--- a/lib/render/getTemplate.js
+++ b/lib/render/getTemplate.js
@@ -1,8 +1,13 @@
 const fs = require('fs/promises');
+const path = require('node:path');
 
-const getTemplate = (filePath) => fs.readFile(filePath,'utf8')
-.then(text => {
-  return text.replace(/include k-scaffold/g,'include /node_modules/@kurohyou/k-scaffold/_k.pug')
-});
+
+const kPugRoot = path.resolve(__dirname, '../../_k.pug');
+
+const getTemplate = (filePath) => fs.readFile(filePath, 'utf8')
+  .then(text => {
+    const relativeRoot = path.relative(path.dirname(path.resolve(filePath)), kPugRoot);
+    return text.replace(/include k-scaffold/g, `include ${relativeRoot}`)
+  });
 
 module.exports = getTemplate;

--- a/lib/render/renderSASS.js
+++ b/lib/render/renderSASS.js
@@ -22,7 +22,7 @@ const renderSASS = async ({source,destination,options={},sfcStyles={},sfcFonts=[
         {
           findFileUrl(url) {
             if(!url.startsWith('k-scaffold')) return null;
-            const fileURL = pathToFileURL(path.resolve(dirname,'node_modules/@kurohyou/k-scaffold'),url.substring(10));
+            const fileURL = pathToFileURL(path.resolve(__dirname,'../..'),url.substring(10));
             const newURL = new URL(fileURL);
             return newURL;
           }


### PR DESCRIPTION
In this PR, we change the path resolution that k-scaffold performs on the `include` PUG statement and `@use` SASS statement that must resolves to k-scaffold installation internals. The resolved path is now computed from a path relative to k-scaffold internals, instead of the source PUG, and thus no longer assumes a production npm installation path.

This fixes #127 and possibly #124.

Of note, we also add the `sass` module that k-scaffold uses to its exports, because defining SCSS function requires to have access to the exact same module that K-Scaffold uses, and a `require('sass-embedded')` no longer provide the same module when K-Scaffold is installed as a path dependency with npm.