### PR TITLE
Fix/phantom rows

### DIFF
--- a/lib/scripts/parse_cascade.js
+++ b/lib/scripts/parse_cascade.js
@@ -14,6 +14,7 @@ const expandCascade = function(cascade,sections){
     return memo;
   },{});
 };
+kFuncs.expandCascade = (sections) => expandCascade(cascades,sections);
 
 const expandRepeating = function(memo,key,cascade,sections){
   key.replace(/((?:attr|act)_)(repeating_[^_]+)_[^_]+?_(.+)/,(match,type,section,field)=>{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "This framework simplifies the task of writing code for Roll20 character sheets. It aims to provide an easier interface between the html and sheetworkers with some minor css templates.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
expose expandCascade as part of the `k` object.