### PR TITLE
Fix/assemble roll

### DIFF
--- a/lib/scripts/kvariables.js
+++ b/lib/scripts/kvariables.js
@@ -42,7 +42,7 @@ const initialSetups = {};
 const allHandlers = {};
 const addFuncs = {};
 
-const kscaffoldJSVersion = '2.7.0';
+const kscaffoldJSVersion = '2.7.1';
 const kscaffoldPUGVersion = '2.7.0';
 /**
  * Defines the rollstring that rolls made using k.startRoll begin with. Defaults to "&{template:default}".

--- a/lib/scripts/sheetworker_aliases.js
+++ b/lib/scripts/sheetworker_aliases.js
@@ -254,9 +254,7 @@ kFuncs.getTranslationByKey = _getTranslationByKey;
  */
 const assembleRoll = (rollObj,rollStart = kFuncs.defaultRollStart) => {
   return Object.entries(rollObj).reduce((str,[field,content])=>{
-    return str += content ?
-      ` {{${field}=${content}}}` :
-      '';
+    return str += ` {{${field}=${content ?? ''}}}`;
   },`${rollStart}`);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "This framework simplifies the task of writing code for Roll20 character sheets. It aims to provide an easier interface between the html and sheetworkers with some minor css templates.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixes an issue with `assembleRoll()` that caused roll template fields that had falsish values that weren't empty strings, `undefined`, or `null` to not be rendered. e.g. a field with a value of `0` would not be rendered.