### PR TITLE
Fix underscore import so it can be used in sheetworkers

### DIFF
--- a/lib/scripts/mock20.js
+++ b/lib/scripts/mock20.js
@@ -1,6 +1,6 @@
 // This code adapted from Nic Bradley's R20 test framework from the WFRP4e official sheet.
 import { vi } from 'vitest';
-import { _ } from 'underscore';
+import _ from 'underscore';
 import translation from './translation.json' assert {type:'json'}
 
 /**


### PR DESCRIPTION
Sheetworkers that use underscore can't currently be tested because the import is incorrect