### PR TITLE
Release 2.7.3: attribute_proxy fixes + watch-loop fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # K-scaffold
 ## Changelog
+### 2.7.3
+- **attributesProxy: correct change detection in the set trap.** Previously stringified the entire attributes/updates container objects instead of the compared field, so same-value writes would always queue a spurious update. The fix compares `obj.attributes[prop]` and `obj.updates[prop]` directly, and uses `hasOwnProperty` so falsy updates (`0`, `''`) participate in the comparison.
+- **attributesProxy: preserve `attributes.set({callback})` across cascade-queue processing.** The callback used to be dropped silently when the queue was non-empty, because the recursive `set()` call inside cascade handling was invoked with no callback. Callbacks are now stashed on `_pendingCallback` so they survive the round trip and fire once when the flush completes.
+- **attributesProxy: defer `setSectionOrder` in `sort()` and `move()` until after pending `setAttrs` commits.** Previously fired synchronously inside the sort, which raced with row creation/writes from the same sort callback. Deferring via an `attributes.set({callback})` ensures setAttrs lands first.
+- **attributesProxy: stop clobbering non-numeric checkbox values with numeric `defaultValue`.** The getter used to substitute the cascade's `defaultValue` whenever `typeof defaultValue === 'number'`, which silently returned `0` for checkboxes whose checked value was a non-numeric string like `/w gm`. The check is now scoped to `type === 'number'`. **Behavior change**: attributes whose cascade has a numeric `defaultValue` but a non-`number` type will now pass through their raw stored value instead of the default. Sheets that relied on the old coercion should declare `type: 'number'` explicitly.
+- **Build: watch-loop fix.** `k-build --watch` would spontaneously process the same source files many times in a row (often 30+) for no visible reason, with the storm eventually clearing on its own. Root cause: external processes on Windows (antivirus, search indexer) touch file metadata and fire `node-watch` events without real content changes; the watcher had no debouncing or change-detection, so each event ran the full pipeline. Fix applies a 300 ms per-file trailing debounce and an MD5 content-hash cache that makes `processSheet` a no-op when the file's bytes are unchanged. Also fixes a latent bug in the `node_modules` skip regex that never matched on Windows (`\node_modules\`) because it only checked forward slashes.
+- **Tests: added `setSectionOrder` mock to `mock20.js`** so generated test frameworks can exercise sort/move paths without `ReferenceError`.
+
 ### 2.5.5
 - Updates k.send so that sheetworkers running on the called sheet will get the correct values even if that sheet has not been opened.
 ### 2.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **attributesProxy: stop clobbering non-numeric checkbox values with numeric `defaultValue`.** The getter used to substitute the cascade's `defaultValue` whenever `typeof defaultValue === 'number'`, which silently returned `0` for checkboxes whose checked value was a non-numeric string like `/w gm`. The check is now scoped to `type === 'number'`. **Behavior change**: attributes whose cascade has a numeric `defaultValue` but a non-`number` type will now pass through their raw stored value instead of the default. Sheets that relied on the old coercion should declare `type: 'number'` explicitly.
 - **Build: watch-loop fix.** `k-build --watch` would spontaneously process the same source files many times in a row (often 30+) for no visible reason, with the storm eventually clearing on its own. Root cause: external processes on Windows (antivirus, search indexer) touch file metadata and fire `node-watch` events without real content changes; the watcher had no debouncing or change-detection, so each event ran the full pipeline. Fix applies a 300 ms per-file trailing debounce and an MD5 content-hash cache that makes `processSheet` a no-op when the file's bytes are unchanged. Also fixes a latent bug in the `node_modules` skip regex that never matched on Windows (`\node_modules\`) because it only checked forward slashes.
 - **Tests: added `setSectionOrder` mock to `mock20.js`** so generated test frameworks can exercise sort/move paths without `ReferenceError`.
+- **Tests: fixed `underscore` import in `mock20.js`** so the generated test framework can use the lodash-style helpers via the default-imported binding. Changes `import { _ } from 'underscore'` to `import _ from 'underscore'`. (Community PR #143 from @CliveEvans.)
+
+### 2.7.2
+- **attributesProxy: fixed row deletion** in repeating sections (`lib/scripts/attribute_proxy.js`).
 
 ### 2.5.5
 - Updates k.send so that sheetworkers running on the called sheet will get the correct values even if that sheet has not been opened.

--- a/__tests__/proxyRegression.test.js
+++ b/__tests__/proxyRegression.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { environment, k, setAttrs, setSectionOrder } from './testFramework';
+
+// Event handlers (on('change:x', accessSheet)) are registered via setTimeout(0) in listeners.js.
+// Wait once at suite start so environment.triggers is populated before any test fires an event.
+const waitForHandlers = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+const getTrigger = (eventName) => {
+  const entry = environment.triggers.find((t) => {
+    const names = t.trigger.split(' ');
+    return names.includes(eventName);
+  });
+  if (!entry) throw new Error(`No trigger registered for ${eventName}. Registered: ${environment.triggers.map((t) => t.trigger).join(', ')}`);
+  return entry.func;
+};
+
+const fireChange = (attrName) => {
+  const listener = getTrigger(`change:${attrName}`);
+  listener({ sourceAttribute: attrName, newValue: environment.attributes[attrName], previousValue: environment.attributes[attrName] });
+};
+
+const fireClick = (actionName) => {
+  const listener = getTrigger(`clicked:${actionName}`);
+  listener({ sourceAttribute: `clicked:${actionName}`, triggerName: `clicked:${actionName}` });
+};
+
+describe('attribute_proxy regression fixes', () => {
+  beforeAll(async () => {
+    await waitForHandlers();
+  });
+  beforeEach(() => {
+    environment.proxyRegressionResults = {};
+  });
+
+  it('fix #1/#2: set trap does not queue same-value writes', () => {
+    environment.attributes.proxy_noop_val = '0';
+    fireChange('proxy_noop_val');
+    const result = environment.proxyRegressionResults.noopWrite;
+    expect(result).toBeDefined();
+    expect(result.before).toBe(0);
+    expect(result.after).toBe(0);
+    expect(result.hasKey).toBe(false);
+  });
+
+  it('fix #3: callback passed to attributes.set() survives cascade queue processing', () => {
+    environment.attributes.proxy_cascade_source = '0';
+    environment.attributes.proxy_cascade_target = '0';
+    fireChange('proxy_cascade_source');
+    const result = environment.proxyRegressionResults.cascadeCallback;
+    expect(result).toBeDefined();
+    expect(result.cbCount).toBe(1);
+  });
+
+  it('fix #4: sort() defers setSectionOrder until after setAttrs commit', () => {
+    setAttrs.mockClear();
+    setSectionOrder.mockClear();
+    fireClick('proxy-sort-trigger');
+    expect(environment.proxyRegressionResults.sortDefersOrder).toEqual({triggered: true});
+    // Both mocks must have been called during the event handling.
+    expect(setSectionOrder.mock.invocationCallOrder.length).toBeGreaterThan(0);
+    expect(setAttrs.mock.invocationCallOrder.length).toBeGreaterThan(0);
+    // The first setAttrs call must precede the first setSectionOrder call.
+    // Under the bug, sort() fires setSectionOrder synchronously before setAttrs commits.
+    // Under the fix, setSectionOrder is scheduled via attributes.set({callback}) so setAttrs fires first.
+    const firstSetAttrs = setAttrs.mock.invocationCallOrder[0];
+    const firstSetSectionOrder = setSectionOrder.mock.invocationCallOrder[0];
+    expect(firstSetAttrs).toBeLessThan(firstSetSectionOrder);
+  });
+
+  it('fix #5: non-numeric stored value is not overridden by numeric defaultValue', () => {
+    environment.attributes.proxy_whisper = '/w gm';
+    fireChange('proxy_whisper');
+    const result = environment.proxyRegressionResults.readWhisper;
+    expect(result).toBeDefined();
+    expect(result.value).toBe('/w gm');
+  });
+});

--- a/__tests__/render/watchUtils.test.js
+++ b/__tests__/render/watchUtils.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { createDebouncer, createContentHashCache, shouldSkipFile } from '../../lib/render/watchUtils';
+
+describe('createDebouncer()', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces rapid calls for the same key into one invocation', () => {
+    const debounce = createDebouncer({ wait: 100 });
+    const fn = vi.fn();
+    debounce('a.pug', () => fn('call-1'));
+    debounce('a.pug', () => fn('call-2'));
+    debounce('a.pug', () => fn('call-3'));
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('call-3');
+  });
+
+  it('invokes per-key independently', () => {
+    const debounce = createDebouncer({ wait: 100 });
+    const fn = vi.fn();
+    debounce('a.pug', () => fn('a'));
+    debounce('b.pug', () => fn('b'));
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn.mock.calls.map(c => c[0]).sort()).toEqual(['a', 'b']);
+  });
+
+  it('does not invoke before wait elapses', () => {
+    const debounce = createDebouncer({ wait: 500 });
+    const fn = vi.fn();
+    debounce('x', fn);
+    vi.advanceTimersByTime(499);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createContentHashCache()', () => {
+  let tmpDir;
+  let tmpFile;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'watchutil-'));
+    tmpFile = path.join(tmpDir, 'sample.pug');
+    await fs.writeFile(tmpFile, 'original contents');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports change on first read for a path (no prior hash)', async () => {
+    const cache = createContentHashCache();
+    const changed = await cache.hasChanged(tmpFile);
+    expect(changed).toBe(true);
+  });
+
+  it('reports no change when content is unchanged', async () => {
+    const cache = createContentHashCache();
+    await cache.hasChanged(tmpFile);
+    const changedAgain = await cache.hasChanged(tmpFile);
+    expect(changedAgain).toBe(false);
+  });
+
+  it('reports change when content differs from cached hash', async () => {
+    const cache = createContentHashCache();
+    await cache.hasChanged(tmpFile);
+    await fs.writeFile(tmpFile, 'modified contents');
+    const changed = await cache.hasChanged(tmpFile);
+    expect(changed).toBe(true);
+  });
+
+  it('reports change (true) when file cannot be read (e.g. deleted)', async () => {
+    const cache = createContentHashCache();
+    await cache.hasChanged(tmpFile);
+    await fs.rm(tmpFile);
+    const changed = await cache.hasChanged(tmpFile);
+    expect(changed).toBe(true);
+  });
+});
+
+describe('shouldSkipFile()', () => {
+  it('skips node_modules paths on Unix-style separators', () => {
+    expect(shouldSkipFile('/project/source/node_modules/foo.js')).toBe(true);
+  });
+
+  it('skips node_modules paths on Windows-style separators', () => {
+    expect(shouldSkipFile('E:\\project\\source\\node_modules\\foo.js')).toBe(true);
+  });
+
+  it('skips .git paths on both separators', () => {
+    expect(shouldSkipFile('/project/.git/index')).toBe(true);
+    expect(shouldSkipFile('E:\\project\\.git\\index')).toBe(true);
+  });
+
+  it('skips generated test framework', () => {
+    expect(shouldSkipFile('__tests__/testFramework.js')).toBe(true);
+    expect(shouldSkipFile('E:\\project\\__tests__\\anything.test.js')).toBe(true);
+    expect(shouldSkipFile('__tests__/foo.mock.js')).toBe(true);
+  });
+
+  it('allows normal source files', () => {
+    expect(shouldSkipFile('/project/source/main.pug')).toBe(false);
+    expect(shouldSkipFile('E:\\project\\source\\main.pug')).toBe(false);
+    expect(shouldSkipFile('E:\\project\\source\\main.scss')).toBe(false);
+    expect(shouldSkipFile('E:\\project\\source\\translation.json')).toBe(false);
+  });
+});

--- a/lib/render/watch.js
+++ b/lib/render/watch.js
@@ -1,33 +1,42 @@
 const watch = require('node-watch');
 
 const processSheet = require('./processSheet');
+const { createDebouncer, createContentHashCache, shouldSkipFile } = require('./watchUtils');
+
+// How long to coalesce rapid node-watch events per file. 300ms is short enough to feel responsive
+// on real saves while still absorbing storms from editor atomic-write sequences and external processes
+// (Windows Search / Defender) that can emit dozens of events for a single logical change.
+const DEBOUNCE_MS = 300;
 
 const kWatch = (argObj) => {
-  watch(argObj.source, 
+  const debounce = createDebouncer({ wait: DEBOUNCE_MS });
+  const hashCache = createContentHashCache();
+
+  watch(argObj.source,
     {
       recursive: true,
       filter(f, skip) {
-        // Basic watch call adapted from node-watch docs
-        // skip node_modules
-        if (/\/node_modules/.test(f)) return skip;
-        // skip .git folder
-        if (/\.git/.test(f)) return skip;
-        // Skip generated test framework
-        if(/testFramework\.js|\.(?:test|mock)\.js/.test(f)) return skip;
-        // only watch for valid sheet files (js, scss, pug)
-        return /\.(js|pug|scss|kscaf|json)$/i.test(f);
+        return shouldSkipFile(f) ? skip : true;
       }
     },
-    async (evt,name)=>{
-      console.log('node-watch name',name);
+    (evt, name) => {
       const runSCSS = name.endsWith('.scss');
       const runPUG = /\.(?:js|pug|kscaf|json)$/i.test(name);
+      if (!runSCSS && !runPUG) return;
 
-      if( !runSCSS && !runPUG ) return;
-      const toRun = argObj.sfc ?
-        {runSCSS:true, runPUG:true} :
-        {runSCSS,runPUG};
-      await processSheet({...argObj,...toRun});
+      debounce(name, async () => {
+        // Only reprocess when the file's content actually changed. External processes touching
+        // metadata (antivirus/indexer/git) produce spurious node-watch events that pass our
+        // debounce window; the hash check filters them out so processSheet is a true no-op.
+        const changed = await hashCache.hasChanged(name);
+        if (!changed) return;
+
+        console.log('node-watch name', name);
+        const toRun = argObj.sfc
+          ? { runSCSS: true, runPUG: true }
+          : { runSCSS, runPUG };
+        await processSheet({ ...argObj, ...toRun });
+      });
     });
 };
 

--- a/lib/render/watchUtils.js
+++ b/lib/render/watchUtils.js
@@ -1,0 +1,75 @@
+const fs = require('fs/promises');
+const crypto = require('crypto');
+
+/**
+ * Creates a per-key trailing debouncer. Use to collapse filesystem event storms into a single invocation per file.
+ * @param {object} opts
+ * @param {number} opts.wait - Milliseconds to wait after the last call before invoking fn.
+ * @returns {(key: string, fn: Function) => void}
+ */
+const createDebouncer = ({ wait }) => {
+  const timers = new Map();
+  return (key, fn) => {
+    const existing = timers.get(key);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      timers.delete(key);
+      fn();
+    }, wait);
+    timers.set(key, timer);
+  };
+};
+
+/**
+ * In-memory cache of MD5 content hashes for watched source files.
+ * Lets the watch loop short-circuit when filesystem events fire for files whose content did not actually change
+ * (external processes like antivirus scans and indexers can emit events that only touch metadata, not bytes).
+ * @returns {{ hasChanged: (filepath: string) => Promise<boolean> }}
+ */
+const createContentHashCache = () => {
+  const hashes = new Map();
+  const hashFor = async (filepath) => {
+    const buf = await fs.readFile(filepath);
+    return crypto.createHash('md5').update(buf).digest('hex');
+  };
+  return {
+    async hasChanged(filepath) {
+      let current;
+      try {
+        current = await hashFor(filepath);
+      } catch {
+        // File unreadable (deleted mid-event, permission flicker): treat as changed so the downstream build runs.
+        hashes.delete(filepath);
+        return true;
+      }
+      const prior = hashes.get(filepath);
+      hashes.set(filepath, current);
+      return prior !== current;
+    }
+  };
+};
+
+const NODE_MODULES_RX = /[\\/]node_modules[\\/]/;
+const GIT_RX = /[\\/]\.git[\\/]/;
+const TEST_ARTIFACT_RX = /testFramework\.js|\.(?:test|mock)\.js$/;
+const SOURCE_EXT_RX = /\.(js|pug|scss|kscaf|json)$/i;
+
+/**
+ * Returns true when the given path should be ignored by the watcher.
+ * Replaces the forward-slash-only regexes in the original watch.js filter so the check works on Windows paths.
+ * @param {string} filepath
+ * @returns {boolean}
+ */
+const shouldSkipFile = (filepath) => {
+  if (NODE_MODULES_RX.test(filepath)) return true;
+  if (GIT_RX.test(filepath)) return true;
+  if (TEST_ARTIFACT_RX.test(filepath)) return true;
+  if (!SOURCE_EXT_RX.test(filepath)) return true;
+  return false;
+};
+
+module.exports = {
+  createDebouncer,
+  createContentHashCache,
+  shouldSkipFile,
+};

--- a/lib/scripts/attribute_proxy.js
+++ b/lib/scripts/attribute_proxy.js
@@ -261,7 +261,11 @@
               sections[arr._section].splice(index,1);
               sections[arr._section].splice(targ,0,id);
               if(vocal){
-                _setSectionOrder(arr._section,sections[arr._section]);
+                attributes.set({
+                  callback(){
+                    _setSectionOrder(arr._section,sections[arr._section]);
+                  }
+                });
               }
             }
           }
@@ -281,9 +285,14 @@
               const bIndex = sections[arr._section].indexOf(b._id);
               return aIndex - bIndex;
             });
-            // if not a silent sort, then apply the reordered section to the sheet via setSectionOrder
+            // Defer setSectionOrder into a set() callback so it fires AFTER pending setAttrs
+            // (the sort may coexist with attribute writes that create the rows being reordered).
             if(vocal){
-              _setSectionOrder(arr._section,sections[arr._section]);
+              attributes.set({
+                callback(){
+                  _setSectionOrder(arr._section,sections[arr._section]);
+                }
+              });
             }
             return arr;
           }
@@ -346,11 +355,19 @@
         }else if(prop === 'set'){
           return function(){
             let {callback,vocal} = arguments[0] ? arguments[0] : {};
+            // Preserve the caller's callback across cascade-queue processing. Without this,
+            // the recursive set() triggered by cascade processing (which passes no callback)
+            // would drop the original caller's callback silently.
+            if(callback){
+              obj._pendingCallback = callback;
+            }
             if(sections && casc && attributes.queue.length){
               const triggerName = attributes.queue.shift();
               const trigger = getCascObj({sourceAttribute:triggerName});
               processChange({trigger,attributes,sections,casc});
             }else{
+              const resolvedCallback = callback || obj._pendingCallback;
+              obj._pendingCallback = undefined;
               if(kFuncs.verboseMode){
                 debug({updates:obj.updates});
               }
@@ -359,9 +376,9 @@
                   Object.entries(obj.repOrders).forEach(([section,order])=>{
                     _setSectionOrder(section,order)
                   });
-                  callback && callback();
+                  resolvedCallback && resolvedCallback();
                 }:
-                callback;
+                resolvedCallback;
               Object.keys(obj.updates).forEach((key)=>obj.attributes[key] = obj.updates[key]);
               const update = obj.updates;
               obj.updates = {};
@@ -401,7 +418,10 @@
           let numRetVal = +retValue;
           if(!Number.isNaN(numRetVal) && retValue !== ''){
             retValue = numRetVal;
-          }else if(cascades[cascRef] && (typeof cascades[cascRef].defaultValue === 'number' || cascades[cascRef].type === 'number')){
+          }else if(cascades[cascRef] && cascades[cascRef].type === 'number'){
+            // Only substitute the default when the input is explicitly typed as a number.
+            // Previously the proxy also substituted when defaultValue was numeric, which caused
+            // non-numeric checkbox values (e.g. '/w gm') to be clobbered by the numeric default (0).
             retValue = cascades[cascRef].defaultValue;
           }
           return retValue;
@@ -414,8 +434,8 @@
           if(/reporder/.test(prop)){
             let section = prop.replace(/_reporder_/,'');
             obj.repOrders[section] = value;
-          }else if(`${obj.attributes}` !== `${value}` || 
-            (obj.updates[prop] && `${obj.updates}` !== `${value}`)
+          }else if(`${obj.attributes[prop]}` !== `${value}` ||
+            (obj.updates.hasOwnProperty(prop) && `${obj.updates[prop]}` !== `${value}`)
           ){
             if(sections && casc){
               let trigger = getCascObj({sourceAttribute:prop});

--- a/lib/scripts/mock20.js
+++ b/lib/scripts/mock20.js
@@ -1,6 +1,6 @@
 // This code adapted from Nic Bradley's R20 test framework from the WFRP4e official sheet.
 import { vi } from 'vitest';
-import { _ } from 'underscore';
+import _ from 'underscore';
 import translation from './translation.json' assert {type:'json'}
 
 /**

--- a/lib/scripts/mock20.js
+++ b/lib/scripts/mock20.js
@@ -75,6 +75,12 @@ const removeRepeatingRow = vi.fn((id) => {
   }
 });
 global.removeRepeatingRow = removeRepeatingRow;
+const setSectionOrder = vi.fn((section, order, callback) => {
+  const sectionName = section.indexOf('repeating_') === 0 ? section : `repeating_${section}`;
+  environment.attributes[`_reporder_${sectionName}`] = Array.isArray(order) ? order.join(',') : order;
+  if (typeof callback === 'function') callback();
+});
+global.setSectionOrder = setSectionOrder;
 const getCompendiumPage = vi.fn((request, callback) => {
   const pages = compendiumData;
   if (!pages)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurohyou/k-scaffold",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "This framework simplifies the task of writing code for Roll20 character sheets. It aims to provide an easier interface between the html and sheetworkers with some minor css templates.",
   "main": "index.js",
   "bin": {

--- a/test_sheet/source/zProxyRegression.test.pug
+++ b/test_sheet/source/zProxyRegression.test.pug
@@ -1,0 +1,73 @@
+//- Standalone sheet dedicated to regression-testing attribute_proxy fixes ported from mmprototype.
+//- Named with leading 'z' so that, in the alphabetical build order of processSheet.js, this file is
+//- the last one processed and its generated bundle is what __tests__/testFramework.js ends up containing.
+//- See __tests__/proxyRegression.test.js for the corresponding tests.
+include k-scaffold
+
+//- Fix #1 & #2: set trap no-op writes should not queue updates
++hidden({name:'proxy noop val',value:0,trigger:{triggeredFuncs:['proxyTest_noopWrite']}})
+
+//- Fix #3: callback preservation across cascade queue
++hidden({name:'proxy cascade source',value:0,trigger:{affects:['proxy_cascade_target'],triggeredFuncs:['proxyTest_cascadeCallback']}})
++hidden({name:'proxy cascade target',value:0,trigger:{calculation:'proxyCalcCascadeTarget'}})
+
+//- Fix #5: non-numeric defaultValue on checkbox should pass through, not be overridden
++checkbox({name:'proxy whisper',value:'/w gm',trigger:{triggeredFuncs:['proxyTest_readWhisper']}})
+
+//- Fix #4: sort/move defer setSectionOrder until after setAttrs commit
++action({name:'proxy sort trigger',trigger:{triggeredFuncs:['proxyTest_sortDefersOrder']}})
++fieldset({name:'proxysort'})
+  +text({name:'label',value:''})
+  +number({name:'weight',value:0})
+
++kscript('proxy-regression')
+  |
+  //- Helper: always read the LIVE scratchpad from environment (beforeEach in tests replaces it).
+  |const _proxyResults = () => {
+  |  if (typeof environment === 'undefined') return {};
+  |  environment.proxyRegressionResults = environment.proxyRegressionResults || {};
+  |  return environment.proxyRegressionResults;
+  |};
+  |
+  |const proxyTest_noopWrite = function({attributes}){
+  |  // Same-value write: fix should not queue; bug always queues.
+  |  const before = Object.keys(attributes.updates).length;
+  |  attributes.proxy_noop_val = attributes.proxy_noop_val;
+  |  const after = Object.keys(attributes.updates).length;
+  |  _proxyResults().noopWrite = {
+  |    before,
+  |    after,
+  |    hasKey: Object.prototype.hasOwnProperty.call(attributes.updates, 'proxy_noop_val')
+  |  };
+  |};
+  |k.registerFuncs({proxyTest_noopWrite});
+  |
+  |const proxyCalcCascadeTarget = function({attributes}){
+  |  return (+attributes.proxy_cascade_source) * 2;
+  |};
+  |k.registerFuncs({proxyCalcCascadeTarget});
+  |
+  |const proxyTest_cascadeCallback = function({attributes}){
+  |  const results = _proxyResults();
+  |  results.cascadeCallback = {cbCount: 0};
+  |  attributes.set({
+  |    callback(){
+  |      _proxyResults().cascadeCallback.cbCount++;
+  |    }
+  |  });
+  |};
+  |k.registerFuncs({proxyTest_cascadeCallback});
+  |
+  |const proxyTest_readWhisper = function({attributes}){
+  |  // Raw stored value is '/w gm'; proxy must return that, not coerce to defaultValue (0).
+  |  _proxyResults().readWhisper = {value: attributes.proxy_whisper};
+  |};
+  |k.registerFuncs({proxyTest_readWhisper});
+  |
+  |const proxyTest_sortDefersOrder = function({attributes}){
+  |  // Just trigger the sort. The test inspects setAttrs/setSectionOrder mocks' invocationCallOrder
+  |  // to determine relative call timing (IIFE-scope bindings mean we cannot wrap via global.*).
+  |  _proxyResults().sortDefersOrder = {triggered: true};
+  |  attributes.repeating_proxysort.sort((a,b) => (+b.weight) - (+a.weight));
+  |};
+  |k.registerFuncs({proxyTest_sortDefersOrder});


### PR DESCRIPTION
## Summary

Roll-up release of `dev/2.7.3` to `main`. Brings in the prior `dev/2.7.2` fixes that were published to npm without merging to main, plus four new fixes ported from the mmprototype sheet project, plus a Windows watch-loop fix.

### 2.7.3
- **attributesProxy: correct change detection in the set trap.** Previously stringified the entire attributes/updates container objects instead of the compared field, so same-value writes always queued a spurious update. Now compares `obj.attributes[prop]` and `obj.updates[prop]` directly, with `hasOwnProperty` so falsy updates (`0`, `''`) participate in the comparison.
- **attributesProxy: preserve `attributes.set({callback})` across cascade-queue processing.** Callbacks used to be dropped silently when the queue was non-empty. Stashed on `_pendingCallback` so they survive the round trip and fire once at the final flush.
- **attributesProxy: defer `setSectionOrder` in `sort()` and `move()` until after pending `setAttrs` commits.** Previously fired synchronously, racing with row creation/writes from the same sort callback.
- **attributesProxy: stop clobbering non-numeric checkbox values with numeric `defaultValue`.** The getter no longer substitutes `defaultValue` when `typeof defaultValue === 'number'`; substitution is now scoped to `type === 'number'`. **Behavior change**: attributes whose cascade has a numeric `defaultValue` but a non-`number` type will now pass through their raw stored value. Sheets that relied on the old coercion should declare `type: 'number'` explicitly.
- **Build: watch-loop fix.** `k-build --watch` would spontaneously process the same source files 30+ times in a row on Windows without any save trigger. Root cause was external processes (antivirus, search indexer) touching file metadata and firing `node-watch` events without real content changes. Fix applies a 300 ms per-file trailing debounce + MD5 content-hash cache so `processSheet` becomes a no-op for spurious events. Also fixes a latent bug in the `node_modules` skip regex that never matched on Windows backslash paths.
- **Tests: `setSectionOrder` mock added** to `mock20.js` so generated test frameworks can exercise sort/move without `ReferenceError`.
- **Tests: underscore import** in `mock20.js` switched from named to default import (community PR #143 from @CliveEvans).

### 2.7.2 (already on npm; backfilled into changelog by this release)
- **attributesProxy: fixed row deletion** in repeating sections.

## Test plan

- [x] `npm test` — 66 tests passing across 19 files (was 50 across 17 before this release).
- [x] `npm run build` — clean (ignoring the intentional `typeError.pug` fixture).
- [x] Proxy fixes #1–#5 verified via TDD with `__tests__/proxyRegression.test.js` (red on prior HEAD, green after port).
- [x] Watch primitives unit-tested in `__tests__/render/watchUtils.test.js` (debouncer, hash cache, cross-platform skip filter).
- [ ] **Manual validation pending**: run `npm run dev` against a real sheet for several days to confirm the watch-loop pattern stops happening. The bug is intermittent and external-process-dependent so it cannot be deterministically reproduced in a unit test.

## Breaking / behavior changes

- **`attributesProxy` getter:** non-numeric stored values are no longer overridden by a numeric `defaultValue` from the cascade. Sheets that explicitly relied on this coercion (e.g., to make `+checkbox` reads return a numeric `0` when the checked value is non-numeric) need to declare `type: 'number'` on the trigger. The motivating bug is described in CHANGELOG fix #5.

## Post-merge

- `npm publish` is manual. Run from `main` after this PR lands. Confirm `package.json` `files` includes everything needed (`index.js`, `_k.pug`, `_index.scss`, `lib/*`).
- Tag the release: `git tag v2.7.3 && git push origin v2.7.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)