### PR TITLE
ci(release): switch npm publish to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -5,19 +5,21 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # `id-token: write` is required for npm Trusted Publishers (OIDC).
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Deploy package
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
@@ -29,19 +29,26 @@ jobs:
     needs: version
     name: Build
     runs-on: ubuntu-latest
+    # `id-token: write` is required for npm Trusted Publishers (OIDC).
+    # Without it, npm publish falls back to token auth and fails.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          # Node 22.14+ ships npm 11.5.1+, which is required for OIDC publishing.
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Deploy package
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN: trusted publishers authenticates via the OIDC
+        # token from `id-token: write`. `--provenance` records a signed
+        # attestation linking this published version to this workflow run.
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Replaces the failing token-based \`npm publish\` (broke 2.8.0 release) with [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers). OIDC tokens are issued per-workflow-run, so there's no long-lived secret to rotate or expire.

## Changes

Both \`release.yml\` (release-published trigger) and \`manual-release.yml\` (workflow_dispatch trigger):

- Add \`permissions: id-token: write\` so the runner can mint an OIDC token.
- Bump \`actions/setup-node@v3\` → \`@v4\` and \`node-version: 18.x\` → \`"22"\`. Trusted publishing requires npm 11.5.1+, which ships with Node 22.14+.
- Drop \`NODE_AUTH_TOKEN\`/\`secrets.NPM_TOKEN\`. The npm CLI auto-detects the OIDC environment when \`registry-url\` is set on \`setup-node\`.
- Add \`--provenance\` to record a signed supply-chain attestation linking the published tarball back to this workflow run (visible on the npm package page).
- Bump \`actions/checkout@v3\` → \`@v4\` for consistency.

## After merge

The 2.8.0 tag/release already exists but the publish failed. Once this PR lands on \`main\`:

1. Re-run the failed Release workflow run for tag 2.8.0 (Actions → Release → failed run → "Re-run all jobs"), **or**
2. Trigger Manual Release via Actions → Manual Release → "Run workflow" → ref \`main\`.

Both will publish 2.8.0 to npm via OIDC. No \`NPM_TOKEN\` secret required (you can delete the old one from repo settings if you want).

## Pre-flight checklist for npmjs.com

- [ ] On npmjs.com → \`@kurohyou/k-scaffold\` → *Settings* → *Trusted Publishers*, the registered workflow filename matches one of \`release.yml\` or \`manual-release.yml\` (case-sensitive, with extension).
- [ ] Repository owner/name on npm matches \`Kurohyou-Studios/k-scaffold\`.
- [ ] If you registered an environment name on npm, the workflow needs an \`environment:\` key matching it. (Not required by default.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)