### PR TITLE
fix(package): declare repository.url so provenance verification passes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "2.8.0",
   "description": "This framework simplifies the task of writing code for Roll20 character sheets. It aims to provide an easier interface between the html and sheetworkers with some minor css templates.",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kurohyou-Studios/k-scaffold.git"
+  },
+  "homepage": "https://github.com/Kurohyou-Studios/k-scaffold#readme",
+  "bugs": {
+    "url": "https://github.com/Kurohyou-Studios/k-scaffold/issues"
+  },
   "bin": {
     "k-build": "cli.mjs"
   },


### PR DESCRIPTION
## Root cause

After PR #150 fixed the npm version (Node 24 → npm 11.x), the publish actually got far enough to surface a real error from the registry — HTTP 422 instead of the bare 404:

\`\`\`
422 Unprocessable Entity - PUT https://registry.npmjs.org/@kurohyou%2fk-scaffold
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/Kurohyou-Studios/k-scaffold" from provenance
\`\`\`

When publishing with \`--provenance\`, npm cross-checks the OIDC token's repo claim against \`package.json#repository.url\`. The field was missing from \`package.json\` entirely, so the comparison fell through to empty-string vs \`https://github.com/Kurohyou-Studios/k-scaffold\` and rejected.

## Fix

Add the standard trio to \`package.json\`:

\`\`\`json
"repository": {
  "type": "git",
  "url": "git+https://github.com/Kurohyou-Studios/k-scaffold.git"
},
"homepage": "https://github.com/Kurohyou-Studios/k-scaffold#readme",
"bugs": {
  "url": "https://github.com/Kurohyou-Studios/k-scaffold/issues"
}
\`\`\`

Bonus: the npm package page will now get working *Repository*, *Homepage*, and *Issues* links.

## After merge

Run **Actions → Release → Run workflow → ref \`main\`**. With Node 24 (npm 11.x) and a populated \`repository.url\`, both checks should pass and 2.8.0 should land on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)