### PR TITLE
Add support for drop/keep and explode functionality in the mock dice roller

### DIFF
--- a/__tests__/mock20.test.js
+++ b/__tests__/mock20.test.js
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { environment, startRoll } from './testFramework';
+
+describe('mock20 dice parser', () => {
+  beforeEach(() => {
+    environment.attributes = {};
+    environment.diceStack = {};
+  });
+
+  it('honors keep-highest syntax in roll expressions', async () => {
+    environment.diceStack[6] = [4, 6, 2];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6k1+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([2, 6, 4]);
+    expect(roll.results.result.result).toBe(8);
+  });
+
+  it('honors keep-lowest syntax in roll expressions', async () => {
+    environment.diceStack[6] = [4, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6kl1+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 4]);
+    expect(roll.results.result.result).toBe(3);
+  });
+
+  it('honors keep-highest longhand syntax in roll expressions', async () => {
+    environment.diceStack[6] = [4, 6, 2];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6kh1+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([2, 6, 4]);
+    expect(roll.results.result.result).toBe(8);
+  });
+
+  it('honors drop-lowest syntax in roll expressions', async () => {
+    environment.diceStack[6] = [4, 6, 2];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6d1+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([2, 6, 4]);
+    expect(roll.results.result.result).toBe(12);
+  });
+
+  it('honors drop-highest syntax in roll expressions', async () => {
+    environment.diceStack[6] = [4, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6dh1+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 4]);
+    expect(roll.results.result.result).toBe(7);
+  });
+
+  it('honors keeping multiple highest dice', async () => {
+    environment.diceStack[6] = [3, 5, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[4d6k2+1]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 5, 3]);
+    expect(roll.results.result.result).toBe(12);
+  });
+
+  it('honors keeping multiple lowest dice', async () => {
+    environment.diceStack[6] = [3, 5, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[4d6kl2+1]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 5, 3]);
+    expect(roll.results.result.result).toBe(5);
+  });
+
+  it('honors dropping multiple lowest dice', async () => {
+    environment.diceStack[6] = [3, 5, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[4d6d2+1]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 5, 3]);
+    expect(roll.results.result.result).toBe(12);
+  });
+
+  it('honors dropping multiple highest dice', async () => {
+    environment.diceStack[6] = [3, 5, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[4d6dh2+1]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 5, 3]);
+    expect(roll.results.result.result).toBe(5);
+  });
+
+  it('preserves existing behavior for rolls without keep modifiers', async () => {
+    environment.diceStack[6] = [4, 6, 2];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([2, 6, 4]);
+    expect(roll.results.result.result).toBe(14);
+  });
+});

--- a/__tests__/mock20.test.js
+++ b/__tests__/mock20.test.js
@@ -88,6 +88,33 @@ describe('mock20 dice parser', () => {
     expect(roll.results.result.result).toBe(5);
   });
 
+  it('honors exploding dice on maximum rolls', async () => {
+    environment.diceStack[6] = [3, 2, 4, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6!+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 4, 2, 3]);
+    expect(roll.results.result.result).toBe(17);
+  });
+
+  it('honors chained exploding dice', async () => {
+    environment.diceStack[6] = [2, 6, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[1d6!]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 6, 2]);
+    expect(roll.results.result.result).toBe(14);
+  });
+
+  it('honors exploding dice compare points', async () => {
+    environment.diceStack[6] = [2, 3, 5, 1, 6];
+
+    const roll = await startRoll('&{template:default} {{result=[[3d6!>5+2]]}}');
+
+    expect(roll.results.result.dice).toEqual([6, 1, 5, 3, 2]);
+    expect(roll.results.result.result).toBe(19);
+  });
+
   it('preserves existing behavior for rolls without keep modifiers', async () => {
     environment.diceStack[6] = [4, 6, 2];
 

--- a/lib/scripts/mock20.js
+++ b/lib/scripts/mock20.js
@@ -174,25 +174,81 @@ const getDiceOrHalf = (size) => {
   return environment.diceStack[size].pop();
 };
 
+const DICE_EXPRESSION_RX = /([0-9]+)?d([0-9]+)(?:(?:kh|kl|dh|dl|k|d)[0-9]+|!(?:(?:>=|<=|>|<|=)-?[0-9]+)?)*/gi;
+
+const parseDiceExpression = (roll) => {
+  const [, number, size, remainder = ''] = roll.match(/^([0-9]+)?d([0-9]+)(.*)$/i) || [];
+  const keepDropMatch = remainder.match(/(kh|kl|dh|dl|k|d)([0-9]+)/i);
+  const explodeMatch = remainder.match(/!(>=|<=|>|<|=)?(-?[0-9]+)?/i);
+  return {
+    number: +number || 1,
+    size: +size,
+    keepDropType: keepDropMatch?.[1]?.toLowerCase(),
+    keepDropCount: +(keepDropMatch?.[2] || 0),
+    explode: !!explodeMatch,
+    explodeOperator: explodeMatch?.[1],
+    explodeTarget: explodeMatch?.[2] ? +explodeMatch[2] : undefined,
+  };
+};
+
+const comparePoint = (value, operator, target) => {
+  switch (operator) {
+    case '>':
+    case '>=':
+      return value >= target;
+    case '<':
+    case '<=':
+      return value <= target;
+    case '=':
+      return value === target;
+    default:
+      return value === target;
+  }
+};
+
+const shouldExplode = (value, size, explode, operator, target) => {
+  if (!explode) return false;
+  if (!operator && typeof target === 'undefined') return value === size;
+  return comparePoint(value, operator, typeof target === 'undefined' ? size : target);
+};
+
 const getDiceRolls = (expression) => {
-  const rolls = expression.match(/([0-9]+)?d([0-9]+)/gi);
+  const rolls = expression.match(DICE_EXPRESSION_RX);
   if (!rolls) return [];
   const allRolls = [];
   rolls.forEach((roll) => {
-    const [number, size] = roll.split(/d/i);
+    const { number, size, explode, explodeOperator, explodeTarget } = parseDiceExpression(roll);
     for (let i = 1; i <= number; i++) {
-      const dice = getDiceOrHalf(size);
+      let dice = getDiceOrHalf(size);
       allRolls.push(dice);
+      while (shouldExplode(dice, size, explode, explodeOperator, explodeTarget)) {
+        dice = getDiceOrHalf(size);
+        allRolls.push(dice);
+      }
     }
   });
   return allRolls;
 };
 
-const applyKeepDropModifier = (rolledDice, modifierType, modifierCount) => {
-  if (!modifierType) return rolledDice;
-  const count = Math.max(0, Math.min(+modifierCount || 0, rolledDice.length));
+const getRollTotals = (dice, number, size, explode, explodeOperator, explodeTarget) => {
+  const dieTotals = [];
+  for (let i = 1; i <= number; i++) {
+    let currentRoll = +dice.shift();
+    let dieTotal = currentRoll;
+    while (shouldExplode(currentRoll, size, explode, explodeOperator, explodeTarget)) {
+      currentRoll = +dice.shift();
+      dieTotal += currentRoll;
+    }
+    dieTotals.push(dieTotal);
+  }
+  return dieTotals;
+};
+
+const applyKeepDropModifier = (rolledDice, keepDropType, keepDropCount) => {
+  if (!keepDropType) return rolledDice;
+  const count = Math.max(0, Math.min(+keepDropCount || 0, rolledDice.length));
   const sortedDice = [...rolledDice].sort((a,b) => a - b);
-  switch (modifierType.toLowerCase()) {
+  switch (keepDropType.toLowerCase()) {
     case 'k':
     case 'kh':
       return sortedDice.slice(-count);
@@ -211,16 +267,15 @@ const applyKeepDropModifier = (rolledDice, modifierType, modifierCount) => {
 const calculateResult = (startExpression, dice) => {
   let expression = startExpression.replace(/\[.+?\]/g,'')
 
-  const rolls = expression.match(/([0-9]+)?d([0-9]+)(kh|kl|dh|dl|k|d)?([0-9]+)?/gi);
+  const rolls = expression.match(DICE_EXPRESSION_RX);
   if (!rolls) return eval(expression);
   rolls.forEach((roll) => {
-    const [, number, , modifierType, modifierCount] = roll.match(/([0-9]+)?d([0-9]+)(kh|kl|dh|dl|k|d)?([0-9]+)?/i);
-    const rolledDice = [];
-    let total = 0;
-    for (let i = 1; i <= (+number || 1); i++) {
-      rolledDice.push(+dice.shift());
-    }
-    total = applyKeepDropModifier(rolledDice, modifierType, modifierCount)
+    const { number, size, keepDropType, keepDropCount, explode, explodeOperator, explodeTarget } = parseDiceExpression(roll);
+    const total = applyKeepDropModifier(
+      getRollTotals(dice, number, size, explode, explodeOperator, explodeTarget),
+      keepDropType,
+      keepDropCount
+    )
       .reduce((memo, value) => memo + value, 0);
     expression = expression.replace(roll, total);
   });

--- a/lib/scripts/mock20.js
+++ b/lib/scripts/mock20.js
@@ -188,20 +188,41 @@ const getDiceRolls = (expression) => {
   return allRolls;
 };
 
+const applyKeepDropModifier = (rolledDice, modifierType, modifierCount) => {
+  if (!modifierType) return rolledDice;
+  const count = Math.max(0, Math.min(+modifierCount || 0, rolledDice.length));
+  const sortedDice = [...rolledDice].sort((a,b) => a - b);
+  switch (modifierType.toLowerCase()) {
+    case 'k':
+    case 'kh':
+      return sortedDice.slice(-count);
+    case 'kl':
+      return sortedDice.slice(0, count);
+    case 'd':
+    case 'dl':
+      return sortedDice.slice(count);
+    case 'dh':
+      return sortedDice.slice(0, sortedDice.length - count);
+    default:
+      return rolledDice;
+  }
+};
+
 const calculateResult = (startExpression, dice) => {
   let expression = startExpression.replace(/\[.+?\]/g,'')
 
-  const rolls = expression.match(/([0-9]+)?d([0-9]+)/gi);
+  const rolls = expression.match(/([0-9]+)?d([0-9]+)(kh|kl|dh|dl|k|d)?([0-9]+)?/gi);
   if (!rolls) return eval(expression);
-  rolls.forEach((roll, index) => {
-    const [number, size] = roll.split(/d/i);
+  rolls.forEach((roll) => {
+    const [, number, , modifierType, modifierCount] = roll.match(/([0-9]+)?d([0-9]+)(kh|kl|dh|dl|k|d)?([0-9]+)?/i);
+    const rolledDice = [];
     let total = 0;
-    for (let i = 1; i <= number; i++) {
-      total += +dice.shift();
+    for (let i = 1; i <= (+number || 1); i++) {
+      rolledDice.push(+dice.shift());
     }
-    expression = expression.replace(/([0-9]+d[0-9]+([+\-*/][0-9]+)?)(.*?)$/gi, "$1");
-    const regex = new RegExp(roll, "gi");
-    expression = expression.replace(regex, total);
+    total = applyKeepDropModifier(rolledDice, modifierType, modifierCount)
+      .reduce((memo, value) => memo + value, 0);
+    expression = expression.replace(roll, total);
   });
 
   return eval(expression);


### PR DESCRIPTION
## Summary

Fix `mock20` dice parsing so Roll20-style keep/drop and exploding dice modifiers are honored instead of summing only the base rolled dice.

## What Changed

- Updated `lib/scripts/mock20.js` to support:
  - `k` / `kh` keep-highest
  - `kl` keep-lowest
  - `d` / `dl` drop-lowest
  - `dh` drop-highest
  - `!` exploding dice on max
  - `!CP` exploding dice with compare points such as `!>5`
- Kept the implementation scoped to the mock dice parser
- Renamed internal keep/drop parser fields to `keepDropType` and `keepDropCount` so the code does not imply a generic modifier system before one exists

## Test Coverage

Added regression coverage in `__tests__/mock20.test.js` through the public `startRoll` mock API with fixed dice values for:

- `3d6k1+2` => `8`
- `3d6kh1+2` => `8`
- `3d6kl1+2` => `3`
- `3d6d1+2` => `12`
- `3d6dh1+2` => `7`
- `4d6k2+1` => keep multiple highest dice
- `4d6kl2+1` => keep multiple lowest dice
- `4d6d2+1` => drop multiple lowest dice
- `4d6dh2+1` => drop multiple highest dice
- `3d6!+2` => explode on max
- `1d6!` => chained explosions
- `3d6!>5+2` => explode on compare point
- plain `3d6+2` as unchanged behavior